### PR TITLE
add mkdocs_monero_metrics_plugin

### DIFF
--- a/docs/en/technical-specs.md
+++ b/docs/en/technical-specs.md
@@ -47,7 +47,7 @@ title: Monero Technical Specification
 ## Current blockchain size
 
 * Pruned node: ~ 57GB as of Jan 2023
-* Complete chain without any pruning: ~138GB as of Jan 2023
+* Complete chain without any pruning: {{ monero_main_file_size }} as of {{ monero_main_file_last_update }} (Height {{ monero_main_block_height }})
 
 ## Emission curve
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,3 +221,12 @@ plugins:
         - locale: nb
           name: Norsk Bokmål
           build: false
+  - monero-metrics:
+      endpoints:
+        - "http://127.0.0.1:9123/metrics"
+      time_format: '%Y-%m-%d %H:%M UTC'
+      defaults:
+        monero_main_file_size: "203.24 GB"
+        monero_main_file_last_update: "2024-09-09 11:51:28"
+        monero_main_block_height: 3233846
+        monero_main_block_timestamp: "2024-09-09 11:50:21"

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ requests==2.32.3
 six==1.16.0
 urllib3==2.2.2
 watchdog==4.0.1
+git+https://github.com/DiosDelRayo/mkdocs_monero_metrics_plugin.git


### PR DESCRIPTION
adds mustache var `{{ monero_main_file_size }}` etc from monero stats exporter to markup