### PR TITLE
docs: add warning to tx_proofs

### DIFF
--- a/docs/en/interacting/monero-wallet-cli-reference.md
+++ b/docs/en/interacting/monero-wallet-cli-reference.md
@@ -254,6 +254,9 @@ Use `help command_name` to learn more.
 
 ### Proofs
 
+!!! warning
+    Transaction proofs (check_tx_key(), InProofs/OutProofs) do not guarantee that funds associated with a proof are spendable. They could be permanently time locked, already spent, or burnt due to duplication of one-time addresses. See [here :link:{title=GitHub}](https://github.com/monero-project/monero/issues/8819#issue-1656289739)
+
 `get_reserve_proof` -> `check_reserve_proof` - prove the balance
 
 `get_spend_proof` -> `check_spend_proof` - prove you made the payment

--- a/docs/en/rpc-library/wallet-rpc.md
+++ b/docs/en/rpc-library/wallet-rpc.md
@@ -359,6 +359,9 @@ $ curl -X POST http://127.0.0.1:18088/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
 
 Prove a transaction by checking its signature.
 
+!!! warning
+    Transaction proofs (check_tx_key(), InProofs/OutProofs) do not guarantee that funds associated with a proof are spendable. They could be permanently time locked, already spent, or burnt due to duplication of one-time addresses. See [here :link:{title=GitHub}](https://github.com/monero-project/monero/issues/8819#issue-1656289739)
+
 Alias:  _None_.
 
 Inputs:


### PR DESCRIPTION
> Transaction proofs (check_tx_key(), InProofs/OutProofs) do not guarantee that funds associated with a proof are spendable. They could be permanently time locked, already spent, or burnt due to duplication of onetime addresses.

https://github.com/monero-project/monero/issues/8819#issue-1656289739

https://93.md.monerodevs.org/rpc-library/wallet-rpc#check_tx_proof
https://93.md.monerodevs.org/interacting/monero-wallet-cli-reference#proofs