### PR TITLE
Correct coinbase-emission confusion in get_coinbase_tx_sum

### DIFF
--- a/docs/en/rpc-library/monerod-rpc.md
+++ b/docs/en/rpc-library/monerod-rpc.md
@@ -841,7 +841,7 @@ $ curl http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"g
 
 ### **get_coinbase_tx_sum**
 
-Get the coinbase amount and the fees amount for n last blocks starting at particular height
+Get the newly emitted coins amount and the fees amount for n last blocks starting at particular height
 
 Alias: _None_ .
 
@@ -853,14 +853,14 @@ Inputs:
 Outputs:
 
 - _credits_ - unsigned int; If payment for RPC is enabled, the number of credits available to the requesting client. Otherwise, 0.
-- _emission_amount_ - unsigned int; Least significant 64 bits for 128 bit integer representing the sum of coinbase rewards in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR."). (See src/rpc/core_rpc_server.cpp store_128)
-- _emission_amount_top64_ - unsigned it; Most significant 64 bits for 128 bit integer representing the sum of coinbase rewards in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR.")
+- _emission_amount_ - unsigned int; Least significant 64 bits for 128 bit integer representing the new coins emitted in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR."). (See src/rpc/core_rpc_server.cpp store_128)
+- _emission_amount_top64_ - unsigned it; Most significant 64 bits for 128 bit integer representing the new coins emitted in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR.")
 - _fee_amount_ - unsigned int; Most significant 64 bits for 128 bit integer representing the sum of fees in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR.").
 - _fee_amount_top64_ - unsigned int; Most significant 64 bits for 128 bit integer representing the sum of fees in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR.").
 - _status_ - string; General RPC error code. "OK" means everything looks good.
 - _top_hash_ - string; If payment for RPC is enabled, the hash of the highest block in the chain. Otherwise, empty.
 - _untrusted_ - boolean; States if the result is obtained using the bootstrap mode, and is therefore not trusted (`true`), or when the daemon is fully synced and thus handles the RPC locally (`false`)
-- _wide_emission_amount_ - string (128 bit hex encoded integer); Sum of coinbase rewards in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR.").
+- _wide_emission_amount_ - string (128 bit hex encoded integer); New coins emitted in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR.").
 - _wide_fee_amount_ - string (128 bit hex encoded integer); Sum of fees in [atomic-units](https://www.getmonero.org/resources/moneropedia/atomic-units.html "Atomic Units refer to the smallest fraction of 1 XMR.").
 
 Example:


### PR DESCRIPTION
"Coinbase" is the sum of new coins emitted and all transaction fees: https://www.getmonero.org/resources/moneropedia/coinbase.html
Emission is just the new coins: https://www.getmonero.org/resources/moneropedia/tail-emission.html

