### PR TITLE
Correct typo in blockchain import example command

### DIFF
--- a/docs/en/interacting/monero-blockchain-import-reference.md
+++ b/docs/en/interacting/monero-blockchain-import-reference.md
@@ -32,7 +32,7 @@ Example:
 
 Go to directory where you unpacked Monero.
 
-`./monero-blockchain-import --stagenet --output-file=/tmp/blockchain.raw`
+`./monero-blockchain-import --stagenet --input-file=/tmp/blockchain.raw`
 
 
 ## Options


### PR DESCRIPTION
Someone must have copy-pasted this from the `monero-blockchain-export` command, which has an `--output-file` parameter. `monero-blockchain-import` uses the `--input-file` parameter.