### PR TITLE
wallet-rpc: correct "address" description for get_transfer_by_txid

### DIFF
--- a/docs/en/rpc-library/wallet-rpc.md
+++ b/docs/en/rpc-library/wallet-rpc.md
@@ -1515,7 +1515,7 @@ Inputs:
 Outputs:
 
 -   _transfer_  - JSON object containing payment information:
-    -   _address_  - string; Address that transferred the funds. Base58 representation of the public keys.
+    -   _address_  - string; Incoming: Address that received the funds. Outgoing: Address that transferred the funds.
     -   _amount_  - unsigned int; Amount of this transfer.
     -   _amounts_  - list; Individual amounts if multiple where received.
     -   _confirmations_  - unsigned int; Number of block mined since the block containing this transaction (or block height at which the transaction should be added to a block if not yet confirmed).


### PR DESCRIPTION
Reported by pcre

Note: when i checked `out` txids, it seems to always show the primary address ad the address which transferred the funds. I'm not sure if it aways shows the account 0 primary address, or the 0 address of each subaccount - the wallet i checked was not using subaccounts. What i do know, is that i didnt see any subaddresses on my `out` query, but all funds on the wallet should be on subaddresses.

The `base58 representation of the public keys` might be implying that it is _always_ the account 0 primary address