### PR TITLE
monerod: update systemd config

### DIFF
--- a/docs/en/running-node/monerod-systemd.md
+++ b/docs/en/running-node/monerod-systemd.md
@@ -103,19 +103,17 @@ Some commands assume Ubuntu but you will easily translate them to your distribut
     [Unit]
     Description=Monero Daemon
     After=network-online.target
+    Requires=network-online.target
 
     [Service]
-    ExecStart=/usr/local/bin/monerod --detach --config-file /etc/monero/monerod.conf --pidfile /run/monero/monerod.pid
-    ExecStartPost=/bin/sleep 0.1
-    PIDFile=/run/monero/monerod.pid
-    Type=forking
+    Type=simple
+    ExecStart=/usr/local/bin/monerod --config-file /etc/monero/monerod.conf --non-interactive
 
     Restart=on-failure
     RestartSec=30
 
     User=monero
     Group=monero
-    RuntimeDirectory=monero
 
     StandardOutput=journal
     StandardError=journal


### PR DESCRIPTION
This pull request updates the example `systemd` service configuration for running `monerod` to simplify the setup and improve reliability. The changes focus on making the service easier to manage and more robust, especially in how it starts and interacts with the system.

Service configuration improvements:

* Changed the `Type` from `forking` to `simple` and removed the use of `--detach` and the `PIDFile`, so `systemd` manages the process directly without needing to track a separate daemonized process.
* Added `Requires=network-online.target` to ensure the service only starts after the network is fully online, improving startup reliability.
* Updated the `ExecStart` command to remove unnecessary options and add `--non-interactive` for better automation and compatibility with `systemd`.
* Removed the `RuntimeDirectory` directive, simplifying the configuration since the service no longer needs to manage a PID file.