### PR TITLE
Landing page: add section entry-point cards to homepage

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,7 +5,53 @@ hide:
 ---
 # Monero Documentation
 
-Monero Docs intends to be a Knowledge Base and User Guide for interacting with Monero.
+Monero Docs is a Knowledge Base and User Guide for interacting with Monero. Pick a starting point below, use the search bar at the top to jump straight to a topic, or browse the navigation bar for the full list of topics.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch-outline:{ .lg .middle } **Get started**
+
+    ---
+
+    New to Monero? Learn the basics, then download and verify the official software.
+
+    [:octicons-arrow-right-24: The basics](interacting/overview.md)
+
+    [:octicons-arrow-right-24: Download & verify](interacting/download-monero-binaries.md)
+
+-   :material-server:{ .lg .middle } **Running a node & mining**
+
+    ---
+
+    Run `monerod`, then mine solo, in a pool, or via P2Pool.
+
+    [:octicons-arrow-right-24: monerod reference](interacting/monerod-reference.md)
+
+    [:octicons-arrow-right-24: Mining guides](interacting/mining/index.md)
+
+-   :material-code-json:{ .lg .middle } **RPC Library**
+
+    ---
+
+    Developer reference for the Node and Wallet JSON-RPC endpoints.
+
+    [:octicons-arrow-right-24: Node RPC](rpc-library/monerod-rpc.md)
+
+    [:octicons-arrow-right-24: Wallet RPC](rpc-library/wallet-rpc.md)
+
+-   :material-flask-outline:{ .lg .middle } **Research & development**
+
+    ---
+
+    How Monero works under the hood: cryptography, address types, mnemonics, and proof of work.
+
+    [:octicons-arrow-right-24: R&D overview](development/index.md)
+
+    [:octicons-arrow-right-24: Cryptography](cryptography/index.md)
+
+</div>
+
+## Contributing
 
 Contributions can be made via issues and pull requests on GitHub, or communicated via the #monero-docs workgroup on Matrix or IRC (libera.chat).
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -25,7 +25,7 @@ Monero Docs is a Knowledge Base and User Guide for interacting with Monero. Pick
 
     Run `monerod`, then mine solo, in a pool, or via P2Pool.
 
-    [:octicons-arrow-right-24: monerod reference](interacting/monerod-reference.md)
+    [:octicons-arrow-right-24: Run a node](running-node/index.md)
 
     [:octicons-arrow-right-24: Mining guides](interacting/mining/index.md)
 

--- a/docs/en/running-node/index.md
+++ b/docs/en/running-node/index.md
@@ -1,0 +1,25 @@
+---
+title: Running a Node
+---
+# Running a Monero Node
+
+Running your own `monerod` node lets you interact with the Monero network
+directly, without trusting a third-party remote node. The pages below cover
+configuring, running as a service, and adding network privacy.
+
+New to running a node? First [download](../interacting/download-monero-binaries.md)
+and [verify](../interacting/verify-monero-binaries.md) the official software, then
+use the guides below to configure and run it.
+
+## Configure monerod
+
+- [`monerod` Reference](../interacting/monerod-reference.md) - the command-line flags and options `monerod` accepts.
+- [Monero Configuration File](../interacting/monero-config-file.md) - set those options in a config file instead of long command lines, with sample configs.
+
+## Run it as a service
+
+- [Running a Node via Systemd](./monerod-systemd.md) - keep `monerod` running in the background and start it on boot.
+
+## Network privacy
+
+- [Tor and I2P](./monerod-tori2p.md) - run your node over Tor and I2P for added privacy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,6 +179,7 @@ markdown_extensions:
   - abbr
   - def_list
   - attr_list
+  - md_in_html         # enables the grid card layout on the landing page
   - footnotes
   - meta
   - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - P2Pool: 'interacting/mining/guides/p2pool/xmrig-p2pool.md'
       - Help: 'interacting/mining/guides/help.md'
   - Monerod:
+    - 'running-node/index.md'
     - Flags: 'interacting/monerod-reference.md'
     - Setup Guide:
       - Systemd: 'running-node/monerod-systemd.md'


### PR DESCRIPTION
## What this does

Replaces the near-empty landing page with a set of entry-point cards for the four top-level sections.

Today the homepage shows only a two-line intro, so the entire documentation is hidden behind the top-nav tabs. To a first-time visitor - especially on mobile, where the tabs collapse into a hamburger - the site looks almost empty. This adds a Material grid-card layout that surfaces the main areas as visible, clickable starting points, plus a short reader-oriented intro that points at the search bar.

## Changes

- `docs/en/index.md` - intro line + a grid of four cards: **Get started**, **Mining & running a node**, **RPC Library**, **Research & development**. Each card links to existing pages.
- `mkdocs.yml` - enable the `md_in_html` Markdown extension, required by Material's grid-card layout (`attr_list` was already enabled).

## Notes

- **English source only.** Other locales' `index.md` are untouched and pick up translations through Weblate as usual.
- **All links are relative** and resolve against existing pages - verified with `mkdocs build --strict` (no broken-link warnings).
- No theme overrides or custom CSS - uses Material's built-in card grid, so it stays consistent with the rest of the site and with upstream conventions.

## Preview

Live preview running this branch: **https://monerodocs.resilience365.com/**

<img width="1944" height="1482" alt="Screenshot 2026-06-04 at 16 39 09" src="https://github.com/user-attachments/assets/f8fd70ea-708b-400a-8f49-11259d1ce28b" />