### PR TITLE
Correct stale field names/types to match the current RPC code

### DIFF
--- a/docs/en/rpc-library/monerod-rpc.md
+++ b/docs/en/rpc-library/monerod-rpc.md
@@ -1244,7 +1244,7 @@ Outputs:
 - _height_ - unsigned int; current blockheight.
 - _prev_id_ - string; previous block id.
 - _seed_hash_ - string; RandomX seed hash.
-- _difficulty_ - unsigned int; network. difficulty.
+- _difficulty_ - string; network. difficulty.
 - _median_weight_ - unsigned int; median block weight.
 - _already_generated_coins_ - unsigned int; coins mined by the network so far.
 - _status_ - string; General RPC error code. "OK" means everything looks good.
@@ -2223,7 +2223,7 @@ Inputs:
 Outputs:
 
 - _status_ - string; General RPC error code. "OK" means everything looks good.
-- _whites_ - array of `public_node` structures defined as follows:
+- _white_ - array of `public_node` structures defined as follows:
   - _host_ - string; The node's IP address. This includes IPv4, IPv6, Onion, and i2p addresses.
   - _last_seen_ - unsigned int; UNIX timestamp of the last time the node was seen.
   - _rpc_credits_per_hash_ - unsigned int; If payment for RPC is enabled, the number of credits the node is requesting per hash. Otherwise, 0.

--- a/docs/en/rpc-library/wallet-rpc.md
+++ b/docs/en/rpc-library/wallet-rpc.md
@@ -953,7 +953,7 @@ Alias:  _None_.
 Inputs:
 
 -   _tag_  - string; (Optional) Tag for filtering accounts.
--   _regex_  - boolean; (Optional) allow regular expression filters if set to true (Defaults to false).
+-   _regexp_  - boolean; (Optional) allow regular expression filters if set to true (Defaults to false).
 -   _strict_balances_  - boolean; (Optional) when `true`, balance only considers the blockchain, when `false` it considers both the blockchain and some recent actions, such as a recently created transaction which spent some outputs, which isn't yet mined.
 Outputs:
 
@@ -2943,7 +2943,7 @@ Inputs:
 Outputs:
 
 -   _is_subaddress_  - boolean; States if the address is a subaddress
--   _payment_  - string; hex encoded
+-   _payment_id_  - string; hex encoded
 -   _standard_address_  - string
 
 Example:


### PR DESCRIPTION
Aligns four docs fields with the v0.18.5.0 wire names/types:

- `get_public_nodes` response: `whites` → `white` (code member is singular).
- `get_accounts` request: `regex` → `regexp` (code wire key is `regexp`).
- `split_integrated_address` response: `payment` → `payment_id`.
- `get_miner_data` response: `difficulty` retyped `unsigned int` → `string` (the code serializes a wide difficulty as a hex string).