### PR TITLE
Remove documented RPC fields absent from the v0.18.5.0 code

### DIFF
--- a/docs/en/rpc-library/monerod-rpc.md
+++ b/docs/en/rpc-library/monerod-rpc.md
@@ -245,7 +245,6 @@ Alias: _None_ .
 
 Inputs:
 
-- _bad_txs_ - boolean; Optional (`false` by default).
 - _bad_blocks_ - boolean; Optional (`false` by default).
 
 Outputs:
@@ -2062,8 +2061,6 @@ Alias: _None_ .
 
 Inputs:
 
-- _credits_ - unsigned int; If payment for RPC is enabled, the number of credits available to the requesting client. Otherwise, 0.
-- _top_hash_ - string; If payment for RPC is enabled, the hash of the highest block in the chain. Otherwise, empty.
 - _amounts_ - array of unsigned int; amounts to look for
 - _cumulative_ - boolean; (optional, default is `false`) States if the result should be cumulative (`true`) or not (`false`)
 - _from_height_ - unsigned int; (optional, default is 0) starting height to check from
@@ -2891,7 +2888,6 @@ Outputs:
 - _invalid_input_ - boolean; Input is invalid (`true`) or valid (`false`).
 - _invalid_output_ - boolean; Output is invalid (`true`) or valid (`false`).
 - _low_mixin_ - boolean; Mixin count is too low (`true`) or OK (`false`).
-- _not_rct_ - boolean; Transaction is a standard ring transaction (`true`) or a ring confidential transaction (`false`).
 - _not_relayed_ - boolean; Transaction was not relayed (`true`) or relayed (`false`).
 - _overspend_ - boolean; Transaction uses more money than available (`true`) or not (`false`).
 - _reason_ - string; Additional information. Currently empty or "Not relayed" if transaction was accepted but not relayed.

--- a/docs/en/rpc-library/wallet-rpc.md
+++ b/docs/en/rpc-library/wallet-rpc.md
@@ -147,7 +147,6 @@ Alias:  _None_.
 Inputs:
 
 -   _address_  - string;
--   _payment_id_  - string; (Optional, defaults to a random ID) 16 characters hex encoded.
 -   _description_  - (optional) string, defaults to "";
 
 Outputs:
@@ -650,15 +649,13 @@ Inputs:
 -   _address_  - string; (Optional) The 95-character public address to set.
 -   _set_description_  - boolean; If true, set the description for this entry to the value of "description".
 -   _description_  - string; (Optional) Human-readable description for this entry.
--   _set_payment_id_  - boolean; If true, set the payment ID for this entry to the value of "payment_id".
--   _payment_id_  - string; (Optional, defaults to a random ID) 16 characters hex encoded.
 
 Outputs:  _none_.
 
 Example:
 
 ```json
-$ curl -X POST http://127.0.0.1:18088/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"edit_address_book","params":{"index":0, "set_address":true, "address":"0b057f69acc1552014cb157138e5c4dd495347d333f68ff0af70494b979aed10", "set_payment_id":true, "payment_id":"60900e5603bf96e3", "set_description":true, "description":"Example description."}' -H 'Content-Type: application/json'
+$ curl -X POST http://127.0.0.1:18088/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"edit_address_book","params":{"index":0, "set_address":true, "address":"0b057f69acc1552014cb157138e5c4dd495347d333f68ff0af70494b979aed10", "set_description":true, "description":"Example description."}' -H 'Content-Type: application/json'
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -1065,7 +1062,6 @@ Outputs:
     -   _address_  - string; Public address of the entry
     -   _description_  - string; Description of this address entry
     -   _index_  - unsigned int;
-    -   _payment_id_  - string;
 
 Example:
 
@@ -1078,13 +1074,11 @@ $ curl -X POST http://127.0.0.1:18088/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
     "entries": [{
       "address": "77Vx9cs1VPicFndSVgYUvTdLCJEZw9h81hXLMYsjBCXSJfUehLa9TDW3Ffh45SQa7xb6dUs18mpNxfUhQGqfwXPSMrvKhVp",
       "description": "Second account",
-      "index": 0,
-      "payment_id": "0000000000000000"
+      "index": 0
     },{
       "address": "78P16M3XmFRGcWFCcsgt1WcTntA1jzcq31seQX1Eg92j8VQ99NPivmdKam4J5CKNAD7KuNWcq5xUPgoWczChzdba5WLwQ4j",
       "description": "Third account",
-      "index": 1,
-      "payment_id": "0000000000000000"
+      "index": 1
     }]
   }
 }
@@ -3356,7 +3350,6 @@ Inputs:
 -   _subaddr_indices_  - array of unsigned int; (Optional) Transfer from this set of subaddresses. (Defaults to empty - all indices)
 -   _subtract_fee_from_outputs_ - array of unsigned int; (Optional) Choose which destinations to fund the tx fee from instead of the change output. The fee will be subtracted evenly from each destination (regardless of amount). Do not use this if recipient requires an exact amount.
 -   _priority_  - unsigned int; Set a priority for the transaction. Accepted Values are: 0-3 for: default, unimportant, normal, elevated, priority.
--   _mixin_  - unsigned int; Number of outputs from the blockchain to mix with (0 means no mixing).
 -   _ring_size_  - unsigned int; Number of outputs to mix in the transaction (this output + N decoys from the blockchain). (Unless dealing with pre rct outputs, this field is ignored on mainnet).
 -   _unlock_time_  - unsigned int; Number of blocks before the monero can be spent (0 to not add a lock).
 -   _get_tx_key_  - boolean; (Optional) Return the transaction key after sending.


### PR DESCRIPTION
Removes bullets for fields not present in the current request/response structs:

- `flush_cache` request: `bad_txs` (not in struct).
- `send_raw_transaction` response: `not_rct` (stale carryover; not in struct).
- `add_address_book` request: `payment_id`; `edit_address_book` request: `payment_id`, `set_payment_id`; `get_address_book` response: `payment_id` (address-book structs dropped these).
- `transfer` request: `mixin` (the request serializes `ring_size`, already documented).
- `get_output_distribution.bin`: moves `credits` and `top_hash` out of the **request** block - they are `rpc_response_base` fields documented under inputs by mistake (response-only).
