### PR TITLE
Remove the start_save_graph/stop_save_graph methods (no longer in monerod)

### DIFF
--- a/docs/en/interacting/monerod-reference.md
+++ b/docs/en/interacting/monerod-reference.md
@@ -369,13 +369,6 @@ You can also type commands directly in the console of the running `monerod` (if 
 | `start_mining <addr> [<threads>] [do_background_mining] [ignore_battery]`   | Ask `monerod`daemon to start mining. Block reward will go to `<addr>`.
 | `stop_mining`                                              | Ask `monerod` daemon to stop mining.
 
-#### Testing Monero itself
-
-| Option                                                     | Description
-|------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------
-| `start_save_graph`                                         | Start saving data for dr Monero.
-| `stop_save_graph`                                          | Stop saving data for dr Monero.
-
 #### Legacy
 
 | Option                                                     | Description

--- a/docs/en/rpc-library/monerod-rpc.md
+++ b/docs/en/rpc-library/monerod-rpc.md
@@ -115,10 +115,8 @@ Some methods include parameters, while others do not. Examples of each JSON RPC 
 - [/set_log_hash_rate](#set_log_hash_rate)
 - [/set_log_level](#set_log_level)
 - [/start_mining](#start_mining)
-- [/start_save_graph](#start_save_graph)
 - [/stop_daemon](#stop_daemon)
 - [/stop_mining](#stop_mining)
-- [/stop_save_graph](#stop_save_graph)
 - [/update](#update)
 
 
@@ -3166,30 +3164,6 @@ $ curl http://127.0.0.1:18081/start_mining -d '{"do_background_mining":false,"ig
 
 
 
-### **/start_save_graph**
-
-Obsolete. Conserved here for reference.
-
-Alias: _None_ .
-
-Inputs: _None_ .
-
-Outputs:
-
-- _status_ - string; General RPC error code. "OK" means everything looks good.
-
-Example:
-
-```json
-$ curl http://127.0.0.1:18081/start_save_graph -H 'Content-Type: application/json'
-
-{
-  "status": "OK"
-}
-```
-
-
-
 ### **/stop_daemon**
 
 Send a command to the daemon to safely disconnect and shut down.
@@ -3235,30 +3209,6 @@ $ curl http://127.0.0.1:18081/stop_mining -H 'Content-Type: application/json'
 {
   "status": "OK",
   "untrusted": false
-}
-```
-
-
-
-### **/stop_save_graph**
-
-Obsolete. Conserved here for reference.
-
-Alias: _None_ .
-
-Inputs: _None_ .
-
-Outputs:
-
-- _status_ - string; General RPC error code. "OK" means everything looks good.
-
-Example:
-
-```json
-$ curl http://127.0.0.1:18081/stop_save_graph -H 'Content-Type: application/json'
-
-{
-  "status": "OK"
 }
 ```
 


### PR DESCRIPTION
`/start_save_graph` and `/stop_save_graph` are documented but absent from the v0.18.5.0 source (`grep save_graph` across the tree returns 0 hits - the feature was removed). Deletes both method sections and their TOC entries.
