### PR TITLE
running-node: add guide for i2p sam setup

### DIFF
--- a/docs/en/running-node/monerod-tori2p.md
+++ b/docs/en/running-node/monerod-tori2p.md
@@ -27,12 +27,23 @@ Some commands assume Ubuntu but you can trivially translate them to your distrib
 
     **Onion and I2P for P2P network** is useful for other nodes as it allows them to relay transactions to your node (using `--tx-proxy` option).
 
+??? question "What is the difference between I2P SOCKS and SAM?"
+
+    SOCKS is a one-size-fits-all approach that makes use of i2pd server tunnels and a SOCKS5 proxy; this requires manual configuration of tunnels and may result in some [metadata leakage](https://i2p.net/en/docs/api/socks/).
+
+    SAM (Simple Anonymous Messaging) is a protocol that lets `monerod` manage its own I2P connections directly, with no manual setup required aside from having an I2P router running. This is the recommended way to run the Monero daemon over I2P.
+
+    However, at present, only SOCKS can be used for connecting to remote nodes from wallet software. SAM can still be used in conjunction with a full local node.
+
 ### Node Configuration
 === "Tor"
 {% include 'tor_template' %}
 
-=== "I2P"
+=== "I2P SOCKS"
 {% include 'i2pd_template' %}
+
+=== "I2P SAM"
+{% include 'i2pd_sam_template' %}
 
 !!! note "(Optional) Publish the node on [monero.fail](https://monero.fail)"
 
@@ -53,7 +64,7 @@ To connect Monero nodes, you have to configure the wallet software:
 
         [:link: _Monero CLI_](../interacting/monero-wallet-cli-reference.md)
 
-=== "I2P"
+=== "I2P SOCKS"
     === "Monero GUI"
 
         1. Navigate to: `Settings -> Interface -> Socks5 proxy` and set the values to `IP Address = 127.0.0.1` and `Port = 4447`
@@ -66,3 +77,10 @@ To connect Monero nodes, you have to configure the wallet software:
         Add the flags `--proxy=127.0.0.1:4447 --daemon-address=http://yourlongb32i2paddress.b32.i2p:18089 --trusted-daemon`
 
         [:link: _Monero CLI_](../interacting/monero-wallet-cli-reference.md)
+
+=== "I2P SAM"
+    === "Monero GUI"
+
+        If using a local node managed through the GUI, go to Settings > Networks (in 'Advanced' mode) and ensure the 'I2P' anonymity network option is checked. Upon restarting the daemon, transactions will be forwarded over I2P.
+
+        [:link: _Monero GUI_](../interacting/monero-wallet-gui-reference.md)

--- a/docs/macros/includes/i2pd_sam_template
+++ b/docs/macros/includes/i2pd_sam_template
@@ -1,0 +1,43 @@
+    !!! success "The end goal"
+        To enable the following services:
+
+        * yourlongb32i2paddress.b32.i2p:18085 - I2P P2P service (for other I2P nodes)
+        * yourlongb32i2paddress.b32.i2p:18089 - I2P RPC service (for wallets connecting over I2P)
+
+        **I2P service for the P2P network** is useful for other full node users as it allows them to broadcast transactions over I2P (using the `--tx-proxy` or `--i2p-sam` options).
+
+        **I2P service for the wallet interface** is useful for wallet users connecting over I2P because it mitigates clearnet and Tor exit node MiTM risks (which are very real). By connecting the wallet to an I2P service, no MiTM attack is realistic because I2P connections are end-to-end encrypted.
+
+    ??? question "Why different P2P ports for clearnet and I2P?"
+        The data served by the I2P P2P port differs from that of clearnet P2P. A different port is required.
+
+    1. Elevate to root:
+        ``` Bash
+        sudo su -
+        ```
+    2. Install i2pd:
+        ``` Bash
+        apt install apt-transport-https
+        wget -q -O - https://repo.i2pd.xyz/.help/add_repo | bash -s -
+        apt update
+        apt install i2pd
+        ```
+    3. The SAM bridge is enabled by default for i2pd. If it's disabled for some reason, add the following to `/etc/i2pd/i2pd.conf` and restart i2pd:
+        ``` ini
+        sam.enabled=true
+        ```
+        ``` Bash
+        systemctl restart i2pd
+        ```
+    4. Add `i2p-sam=127.0.0.1:7656` to your Monero [**config file** :link:{ title="Monerod Config" }]{{ config }}:
+
+        ``` ini
+        i2p-sam=127.0.0.1:7656
+        ```
+
+        This overrides the `tx-proxy` and `anonymous-inbound` options for I2P: `monerod` will connect to the SAM bridge, generate an I2P destination, and manage the inbound and outbound I2P connections automatically.
+
+    5. Start `monerod`. To find the Base32 address of your hidden service, go to the [SAM sessions page](http://127.0.0.1:7070/?page=sam_sessions) in the i2pd web console, click on the running session, and copy the `.b32.i2p` address.
+    ??? info "Back up private destination key"
+        You may want to back up the `i2p_private_key` file in the `monerod` data directory to retain control over your I2P address/destination.
+    !!! note "(Optional) Register a short and memorable .i2p domain on [reg.i2p](http://reg.i2p)"


### PR DESCRIPTION
This should probably not be merged until it's supported in `monerod` (and maybe the GUI).