### PR TITLE
chore: rollup of several commits

### DIFF
--- a/docs/en/interacting/download-monero-binaries.md
+++ b/docs/en/interacting/download-monero-binaries.md
@@ -12,7 +12,7 @@ We recommend downloading Monero binaries directly from GitHub:
 
 GUI is a graphical desktop wallet.
 
-CLI is a commandline desktop wallet.
+CLI is a command-line desktop wallet.
 
 If you need more guidance check [download Monero](https://getmonero.org/downloads) section on Monero website.
 

--- a/docs/en/interacting/mining/index.md
+++ b/docs/en/interacting/mining/index.md
@@ -3,17 +3,17 @@ title: Mining Monero
 ---
 # Mining Monero
 
-Monero is a Proof Of Work (**[POW](../../proof-of-work/pow-in-cryptocurrencies.md)**) cryptocurrency.    
+Monero is a Proof-of-Work (**[PoW](../../proof-of-work/pow-in-cryptocurrencies.md)**) cryptocurrency.    
 There are multiple ways to take part in mining Monero.
 
 - [Solo Mining](./guides/solo/index.md)
 - [Pool Mining](./guides/pool/xmrig-pool.md)
 - [P2Pool Mining](./guides/p2pool/xmrig-p2pool.md)
 
-Solo Mining is the purest, most decentralized and private form of mining, but requires the most patience.
+Solo mining is the purest, most decentralized and private form of mining, but requires the most patience.
 
-Pool Mining is the most convenient form of mining, but it comes with centralization.
+Pool mining is the most convenient form of mining, but it comes with centralization.
 
-P2Pool Mining is decentralized and has the most frequent payouts, but has pool-like privacy and consolidations of payouts can be costly.
+P2Pool mining is decentralized and has the most frequent payouts, but has pool-like privacy and consolidations of payouts can be costly.
 
 - [Troubleshooting XMRig](./guides/help.md)

--- a/docs/en/interacting/monero-config-file.md
+++ b/docs/en/interacting/monero-config-file.md
@@ -76,5 +76,5 @@ daemon-address=YOUR.NODE.IP:38081
 # Log file
 log-file=/tmp/monero-wallet-cli.log
 
-# wallet-file=~/.bitmonero/stagenet/wallets/MoneroExampleStagenetWallet
+# wallet-file=/home/user/.bitmonero/stagenet/wallets/MoneroExampleStagenetWallet
 ```

--- a/docs/en/interacting/monero-wallet-cli-reference.md
+++ b/docs/en/interacting/monero-wallet-cli-reference.md
@@ -109,6 +109,7 @@ Wallet depends on a full node for all non-local operations. The following option
 | Option                      | Description
 |-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------
 | `--wallet-file <arg>`       | Open existing wallet. Example: <br/><br/>`./monero-wallet-cli --stagenet --wallet-file $HOME/.bitmonero/stagenet/wallets/MoneroExampleStagenetWallet` <br><br/>This is only for wallet files generated with `monero-wallet-cli`, `monero-wallet-gui`, or `monero-wallet-rpc` tools. If you have other type of wallet then see importing options.
+| `--wallet-dir <arg>`        | Specify a directory for loading and saving wallet files. Must be an absolute path.
 | `--password <arg>`          | Provide wallet password as a parameter instead of interactively. Remember to escape/quote as needed. <br><br>**Not recommended** because the password will remain in your command history and will also be visible in the process table. For automation prefer `--password-file`. <br><br>The option also works in combination with `--generate-new-wallet`.
 | `--password-file <arg>`     | Provide password as a file in stead of interactively. Trailing `\n` are discarded when reading the password file. <br><br>Prefer this over `--password` if you automate wallet access. Make sure the password file is meaningfully separated from the wallet file. Otherwise it provides no security benefit. <br><br>The option also works in combination with `--generate-new-wallet`.
 
@@ -160,12 +161,12 @@ These options are either legacy or rarely useful.
 | `--shared-ringdb-dir <arg>`  | Set shared ring database path. [No longer worthwhile](https://www.reddit.com/r/Monero/comments/9rtnpx/are_there_any_updated_blackball_databases/).
 | `--create-address-file`      | Has no effect. The `*.address.txt` file is created regardless of this option.
 | `--electrum-seed <arg>`      | Provide mnemonic seed as a commandline option for `--restore-deterministic-wallet` instead of interactively. This is not recommended b/c the seed will be saved in your command history and also visible in the process list.
-| `--generate-from-json <arg>` | You would run `monero-wallet-rpc` to use this option. It seems exposed in `monero-wallet-cli` by accident.
-| `--tx-notify <arg>`          | You would run `monero-wallet-rpc` to use this option. It seems exposed in `monero-wallet-cli` by accident.
+| `--generate-from-json <arg>` | Generate wallet from JSON format file
+| `--tx-notify <arg>`          | Run a program for each new incoming transaction, '%s' will be replaced by the transaction hash. This feature is better suited for use in conjunction with `monero-wallet-rpc`.
 
 ## Defaults
 
-Wallet files are created and seek in current directory. This is rarely what you want. Use `--wallet-file` and similar options to control this.
+Wallet files are created and seek in current directory. This is rarely what you want. Use `--wallet-file`, `--wallet-dir`, and similar options to control this.
 
 Log files are created in the same directory as `monero-wallet-cli` binary. Use `--log-file` to specify the location.
 
@@ -351,9 +352,6 @@ but got superseded by `get_spend_proof`.
 `bc_height` - show blockchain height (superseded with `status`)
 
 `sweep_unmixable` - only relevant for very old wallets (<= 2016); send all unmixable outputs to yourself with ring_size 10
-
-`locked_sweep_all` - see
-
 
 `rescan_bc` - rescan the blockchain from scratch, losing any information which can not be recovered from the blockchain itself
 

--- a/docs/en/interacting/verify-monero-binaries.md
+++ b/docs/en/interacting/verify-monero-binaries.md
@@ -13,7 +13,7 @@ This is a one time action. Skip this step for subsequent Monero releases.
 
 Monero core developers sign a list of hashes of released binaries.
 
-BinaryFate is Monero core developer who signs the releases.
+binaryFate is a Monero core developer who signs the releases.
 His public key is available on GitHub in the project source code.
 Import binaryFate's public key to your keyring:
 
@@ -26,13 +26,13 @@ Trust binaryFate's public key (fingerprint must be exactly this):
     4
 
 !!! danger
-    If key with this fingerprint was not found then remove imported key immediately (gpg --delete-keys ...).
+    If the key with this fingerprint was not found, then remove the imported key immediately (gpg --delete-keys ...).
     That would mean the key changed (likely was compromised).
 
 ## 2. Verify signature of hash list (hashes.txt)
 
 The list of binaries and their hashes is published on [getmonero.org](https://www.getmonero.org/downloads/hashes.txt) and a few other places like release notes on [r/monero](https://reddit.com/r/monero).
-Please note the publication channel does not matter as long as you properly verify the signature!                                                                        u
+Please note the publication channel does not matter as long as you properly verify the signature!
 
 To verify these are real hashes (not tampered with) run:
 

--- a/docs/en/technical-specs.md
+++ b/docs/en/technical-specs.md
@@ -30,7 +30,7 @@ title: Monero Technical Specification
 
 ## Block time
 
-* 2 minutes
+* 2 minutes (was 1 minute before hardfork v1)
 * may change in the future as long as emission curve is preserved
 
 ## Block reward
@@ -93,12 +93,12 @@ title: Monero Technical Specification
 
 For the full node (`monerod`):
 
-* dandelion++
-* assurance: won't protect against ISP/VPN provider, won't protect against the very first remote node in Dandellion++ protocol
-* for the full protection user must manually wrap `monerod` with Tor
+* Dandelion++ makes transaction propagation less traceable over public networks
+* Assurance: won't protect against ISP/VPN provider, won't protect against the very first remote node in Dandelion++ protocol
+* For full protection, the user must manually wrap `monerod` with Tor
 
 For the wallet (`monero-wallet-gui` or `monero-wallet-cli`):
 
-* typically wallet runs on the same machine as full node so there is no risk
-* if wallet connects to remote full node, there is no IP protection by default
-    * user must manually wrap wallet with Tor or I2P
+* Typically, the wallet runs on the same machine as a full node so there is no risk
+* If the wallet is using a remote node, there is no IP protection by default
+    * The user must manually the wrap the wallet with Tor or I2P


### PR DESCRIPTION
- Fixes some grammar issues/nitpicks
- Fixes the description of two options in `monero-wallet-cli`
- Adds the `wallet-dir` option for `monero-wallet-cli`
- Changes config files to use absolute paths