### PR TITLE
proof-of-work: replace dead CryptoNote CNS008 links

### DIFF
--- a/docs/en/proof-of-work/cryptonight.md
+++ b/docs/en/proof-of-work/cryptonight.md
@@ -93,7 +93,7 @@ The next payload is encryption result of the previous payload.
 
 Each 128-byte payload is actually encrypted 10 times.
 
-The details are a bit more nuanced, see "Scratchpad Initialization" in [CryptoNote Standard](https://cryptonote.org/cns/cns008.txt).  
+The details are a bit more nuanced, see "Scratchpad Initialization" in [CryptoNote Standard](https://gist.github.com/laanwj/6b52e6cc516c0fa32637287aa83df38c#file-cns008-txt).  
 
 ### Step 2: memory-hard loop
 
@@ -152,7 +152,7 @@ CryptoNight proof of work remains one of the most controversial aspect of Monero
 
 ## Reference
 
-* [CryptoNight hash function](https://cryptonote.org/cns/cns008.txt) description in the CryptoNote Standard
+* [CryptoNight hash function](https://gist.github.com/laanwj/6b52e6cc516c0fa32637287aa83df38c#file-cns008-txt) description in the CryptoNote Standard
 * [CryptoNight v2 source code](https://github.com/monero-project/monero/blob/master/src/crypto/slow-hash.c)
     * The entry point is `cn_slow_hash()` function. Manually removing support and optimizations for multiple architectures should help you understand the actual code. 
 * "Egalitarian Proof of Work" chapter in [CryptoNote whitepaper](https://downloads.getmonero.org/whitepaper_annotated.pdf) 


### PR DESCRIPTION
## Summary
`https://cryptonote.org/cns/cns008.txt` is no longer reachable (connection fails from here). This updates both CryptoNight doc references to the preserved CNS-008 text mirror:

https://gist.github.com/laanwj/6b52e6cc516c0fa32637287aa83df38c#file-cns008-txt

(same file contents: starts with `CRYPTONOTE STANDARD 008`)

## Scope / #109
Issue #109 listed two dead links:

1. **CryptoNote CNS008** — fixed here  
2. **Monero Outreach RandomX article** — currently returns HTTP 200 again from this host; left unchanged. Broader RandomX page work is already in open PR #47

Happy to adjust the replacement URL if maintainers prefer a different archive host.

## Test plan
- [x] Old URL fails / new gist URL returns 200 and contains CNS008 text  
- [x] Only `docs/en/proof-of-work/cryptonight.md` touched (2 link sites)  
- [ ] Maintainer preference on gist vs another mirror

Partial fix for #109