### PR TITLE
docs: note payment proofs do not imply spendable funds

### DIFF
--- a/docs/en/interacting/monero-wallet-cli-reference.md
+++ b/docs/en/interacting/monero-wallet-cli-reference.md
@@ -325,6 +325,9 @@ These allow to learn and verify transaction's private key `r`.
 This was useful to create a [proof of payment](https://www.getmonero.org/resources/user-guides/prove-payment.html)
 but got superseded by `get_spend_proof`.
 
+!!! warning
+    A successful `check_tx_key` (or related tx / InProof / OutProof check) shows that an amount was directed to an address in that transaction. It does **not** prove the funds are still spendable by the recipient. Outputs may be time-locked, already spent, or unspendable after one-time address reuse. See [monero#8819](https://github.com/monero-project/monero/issues/8819#issue-1656289739). The same limit applies to the getmonero.org prove-payment guide.
+
 `get_tx_key <txid>`
 
 `check_tx_key <txid> <txkey> <address>`

--- a/docs/en/rpc-library/wallet-rpc.md
+++ b/docs/en/rpc-library/wallet-rpc.md
@@ -334,6 +334,9 @@ $ curl -X POST http://127.0.0.1:18088/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
 
 Check a transaction in the blockchain with its secret key.
 
+!!! warning
+    A matching key proves an amount was paid **to** the given address in that tx. It does **not** mean those funds are still spendable (time lock, already spent, or burnt one-time address). Same caveat as InProofs/OutProofs — see [monero#8819](https://github.com/monero-project/monero/issues/8819#issue-1656289739).
+
 Alias:  _None_.
 
 Inputs:


### PR DESCRIPTION
## Summary

Puts the spendability caveat where operators actually look when proving payment.

- CLI reference: under **Tx private key** (`get_tx_key` / `check_tx_key`), next to the getmonero prove-payment link
- wallet-rpc: under **check_tx_key** (the Proofs list and `check_tx_proof` already had a similar note)

## Why

Issue #92 / monero-site#2151 / monero#8819: transaction proofs do not mean funds are still spendable (time lock, already spent, burnt one-time address).

monero-docs already warned under the general Proofs heading; readers following the tx-key path could miss it.

## Fixes

Fixes #92
