### PR TITLE
running-node: add i2p java guide for socks

### DIFF
--- a/docs/en/running-node/monerod-tori2p.md
+++ b/docs/en/running-node/monerod-tori2p.md
@@ -32,7 +32,11 @@ Some commands assume Ubuntu but you can trivially translate them to your distrib
 {% include 'tor_template' %}
 
 === "I2P"
+    === "i2pd"
 {% include 'i2pd_template' %}
+
+    === "I2P Java"
+{% include 'i2p_java_template' %}
 
 !!! note "(Optional) Publish the node on [monero.fail](https://monero.fail)"
 

--- a/docs/macros/includes/i2p_java_template
+++ b/docs/macros/includes/i2p_java_template
@@ -1,0 +1,44 @@
+{% include 'i2p_socks_end_goal_template' %}
+
+        1. Install I2P Java, start router
+
+            Follow [these instructions](https://i2p.net/en/downloads) to install I2P Java on your system, then start the router:
+            ``` Bash
+            sudo systemctl start i2p.service
+            ```
+
+            Alternatively, if you downloaded a binary:
+            ``` Bash
+            ./i2p/i2prouter start
+            ```
+
+        2. Create a SOCKS tunnel
+
+            The SOCKS proxy tunnel is not enabled by default in I2P Java. Open the tunnel manager at `http://127.0.0.1:7657/i2ptunnel/`, click on `Tunnel Wizard`, select a client tunnel, select type `SOCKS 4/4a/5`, and set the port to `4447`.
+
+        3. Create server tunnels for P2P and RPC
+
+            You will need to add two server tunnels to allow for inbound P2P and RPC connections for your node. Use ports 18085 and 18089 respectively.
+
+            From the same tunnel manager, click on `Tunnel Wizard` again, choose a server tunnel of type `Standard`, set the target host to `127.0.0.1`, and the target port to the desired number. Repeat this for both tunnels and save, then start each tunnel.
+
+            This will create hidden service keys under your I2P config directory, usually `~/.i2p/` for a user install or `/var/lib/i2p/i2p-config/` for a system service install; you may want to back these up.
+
+            Get the hostname of your hidden service node from the tunnel list once the tunnel has started, under "I2P Hidden Services" (this can take a couple of minutes on first startup).
+
+        4. Modify the config file
+
+            Copy the result into your Monero [**config file** :link:{ title="Monerod Config" }]{{ config }}, enabling these options:
+            ``` ini
+            anonymous-inbound=yourlongb32i2paddress.b32.i2p,127.0.0.1:18085
+            tx-proxy=i2p,127.0.0.1:4447,disable_noise
+            ```
+
+            Replace `yourlongb32i2paddress.b32.i2p` with your Base32 address.
+
+        5. The node is now available on I2P. You can check that the service is working by using `curl`:
+
+            ``` Bash
+            curl -x socks5h://127.0.0.1:4447 http://yourlongb32i2paddress.b32.i2p:18089/get_info
+            ```
+{% include 'reg_i2p_template' %}

--- a/docs/macros/includes/i2p_socks_end_goal_template
+++ b/docs/macros/includes/i2p_socks_end_goal_template
@@ -1,0 +1,8 @@
+        !!! success "The end goal"
+            To enable the following services:
+
+            * yourlongb32i2paddress.b32.i2p:18085 - I2P P2P service (for other I2P nodes)
+            * yourlongb32i2paddress.b32.i2p:18089 - I2P RPC service (for wallets connecting over I2P)
+
+        ??? question "Why different P2P ports for clearnet and I2P?"
+            A: The data served by the I2P P2P port differs from that of clearnet P2P. A different port is required.

--- a/docs/macros/includes/i2pd_template
+++ b/docs/macros/includes/i2pd_template
@@ -1,70 +1,59 @@
-    !!! success "The end goal"
-        To enable the following services:
+{% include 'i2p_socks_end_goal_template' %}
 
-        * yourlongb32i2paddress.b32.i2p:18085 - i2p P2P service (for other i2p nodes)
-        * yourlongb32i2paddress.b32.i2p:18089 - i2p RPC service (for wallets connecting over i2p)
-
-        **I2P service for P2P network** is useful for other full node users as it allows them to broadcast transactions over I2P (using `--tx-proxy` option).
-
-        **I2P service for wallet interface** is useful for wallet users connecting over I2P because it mitigates Clearnet and Tor exit node MiTM risks (which are very real). By connecting wallet to an I2P service, no MiTM attack is realistic because I2P connections are end-to-end encrypted.
-
-    ??? question "Why different P2P ports for clearnet and i2p?"
-        A: The data served by the i2p p2p port differs from clearnet P2P. A different port is required
-
-    1. Elevate to root:
-        ``` Bash
-        sudo su -
-        ```
-    2. Install i2pd:
-        ``` Bash
-        apt install apt-transport-https
-        wget -q -O - https://repo.i2pd.xyz/.help/add_repo | bash -s -
-        apt update
-        apt install i2pd
-        ```
-    3. Create a server tunnel for the Monero P2P and RPC ports:
-        ``` ini
-        cat << EOF > /etc/i2pd/tunnels.conf.d/monero-mainnet.conf
-        [monero-node]
-        type = server
-        host = 127.0.0.1
-        # Anonymous inbound port
-        port = 18085
-        inport = 0
-        keys = monero-mainnet.dat
-
-        [monero-rpc]
-        type = server
-        host = 127.0.0.1
-        # Restricted RPC port
-        port = 18089
-        keys = monero-mainnet.dat
-        EOF
-        ```
-    4. Restart i2pd:
-        ``` Bash
-        systemctl restart i2pd
-        ```
-    5. Find the new b32 address of the node:
-
-        === "Terminal"
+        1. Elevate to root:
             ``` Bash
-            curl -s http://127.0.0.1:7070/?page=i2p_tunnels | grep -Eo "[a-zA-Z0-9./?=_%:-]*" | grep "18089"
+            sudo su -
             ```
-        === "Web console"
-            Go to the web console at 127.0.0.1:7070 -> [I2P tunnels page](http://127.0.0.1:7070/?page=i2p_tunnels).    
-            Look for Server tunnels and you will see an address like **_`yourlongb32i2paddress.b32.i2p`_** next to **`monero-node`**.
+        2. Install i2pd:
+            ``` Bash
+            apt install apt-transport-https
+            wget -q -O - https://repo.i2pd.xyz/.help/add_repo | bash -s -
+            apt update
+            apt install i2pd
+            ```
+        3. Create a server tunnel for the Monero P2P and RPC ports:
+            ``` ini
+            cat << EOF > /etc/i2pd/tunnels.conf.d/monero-mainnet.conf
+            [monero-node]
+            type = server
+            host = 127.0.0.1
+            # Anonymous inbound port
+            port = 18085
+            inport = 0
+            keys = monero-mainnet.dat
 
-    6. Copy the result into your Monero [**config file** :link:{ title="Monerod Config" }]{{ config }}, enabling these options:
+            [monero-rpc]
+            type = server
+            host = 127.0.0.1
+            # Restricted RPC port
+            port = 18089
+            keys = monero-mainnet.dat
+            EOF
+            ```
+        4. Restart i2pd:
+            ``` Bash
+            systemctl restart i2pd
+            ```
+        5. Find the new Base32 address of the node:
 
-        ``` ini
-        anonymous-inbound=yourlongb32i2paddress.b32.i2p,127.0.0.1:18085
-        tx-proxy=i2p,127.0.0.1:4447,disable_noise
-        ```
+            === "Terminal"
+                ``` Bash
+                curl -s http://127.0.0.1:7070/?page=i2p_tunnels | grep -Eo "[a-zA-Z0-9./?=_%:-]*" | grep "18089"
+                ```
+            === "Web console"
+                Go to the web console at 127.0.0.1:7070 -> [I2P tunnels page](http://127.0.0.1:7070/?page=i2p_tunnels).    
+                Look for Server tunnels and you will see an address like **_`yourlongb32i2paddress.b32.i2p`_** next to **`monero-node`**.
 
-        Replace `yourlongb32i2paddress.b32.i2p` with your b32 address.
-    7. The node is now available on i2p. You can check that the service is working by using curl:
-        ``` Bash
-        curl -x socks5h://127.0.0.1:4447 http://yourlongb32i2paddress.b32.i2p:18089/get_info
-        ```
-    !!! note "(Optional) Register short and memorable .i2p domain on [reg.i2p](http://reg.i2p)"
+        6. Copy the result into your Monero [**config file** :link:{ title="Monerod Config" }]{{ config }}, enabling these options:
+
+            ``` ini
+            anonymous-inbound=yourlongb32i2paddress.b32.i2p,127.0.0.1:18085
+            tx-proxy=i2p,127.0.0.1:4447,disable_noise
+            ```
+
+            Replace `yourlongb32i2paddress.b32.i2p` with your Base32 address.
+        7. The node is now available on I2P. You can check that the service is working by using `curl`:
+            ``` Bash
+            curl -x socks5h://127.0.0.1:4447 http://yourlongb32i2paddress.b32.i2p:18089/get_info
+            ```
+{% include 'reg_i2p_template' %}

--- a/docs/macros/includes/reg_i2p_template
+++ b/docs/macros/includes/reg_i2p_template
@@ -1,0 +1,1 @@
+        !!! note "(Optional) Register a short and memorable `.i2p` domain on [reg.i2p](http://reg.i2p)"


### PR DESCRIPTION
- Adds a setup guide for running a node over I2P SOCKS using I2P Java
- Refactors some duplicated text into templates
- Fixes a few random grammar inconsistencies and such

The I2P Java guide is based off of the guide in the [P2Pool docs](https://github.com/SChernykh/p2pool/blob/master/docs/I2P.MD) (which was also written by me).